### PR TITLE
Enable logging by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,6 @@ The `mitsubishi_itp` component also supports MHK2 thermostats which can be conne
     #   tx_pin:
     #     number: GPIO21
   ```
-
-  Logging can then be reenabled if desired:
-  ```yaml
-  logger:
-    # baud_rate: 0
-    baud_rate: 115200
-  ```
 </details>
 
 <details>


### PR DESCRIPTION
Since all Mahtanar boards use the ESP32-C3, logging is by default connected to the USB_SERIAL_JTAG port, not either of the hardware UARTs. This means there is no conflict between logging and using both hardware UARTs to connect to the heatpump and thermostat.

The configs for the boards can be updated to remove the section which disables the logger, and then the README no longer needs to include instructions for optionally enabling it.